### PR TITLE
Correct repo references in image metadata and swagger

### DIFF
--- a/dockerfiles/Dockerfile_0
+++ b/dockerfiles/Dockerfile_0
@@ -23,11 +23,11 @@ LABEL org.opencontainers.image.title="Trip Insights - User Profile (Java) API" \
       org.opencontainers.image.created=$IMAGE_CREATE_DATE \
       org.opencontainers.image.version=$IMAGE_VERSION \
       org.opencontainers.image.authors="Microsoft" \
-      org.opencontainers.image.url="https://github.com/vyta/openhack-containers/blob/master/dockerfiles/Dockerfile_0" \
-      org.opencontainers.image.documentation="https://github.com/vyta/openhack-containers/blob/master/src/user-java/README.md" \
+      org.opencontainers.image.url="https://github.com/Azure-Samples/openhack-containers/blob/master/dockerfiles/Dockerfile_0" \
+      org.opencontainers.image.documentation="https://github.com/Azure-Samples/openhack-containers/blob/master/src/user-java/README.md" \
       org.opencontainers.image.vendor="Microsoft" \
       org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.source="https://github.com/vyta/openhack-containers.git" \
+      org.opencontainers.image.source="https://github.com/Azure-Samples/openhack-containers.git" \
       org.opencontainers.image.revision=$IMAGE_SOURCE_REVISION 
 
 # add debugging utilities

--- a/dockerfiles/Dockerfile_1
+++ b/dockerfiles/Dockerfile_1
@@ -28,11 +28,11 @@ LABEL org.opencontainers.image.title="TripInsights - TripViewer Site" \
       org.opencontainers.image.created=$IMAGE_CREATE_DATE \
       org.opencontainers.image.version=$IMAGE_VERSION \
       org.opencontainers.image.authors="Microsoft" \
-      org.opencontainers.image.url="https://github.com/vyta/openhack-containers/blob/master/dockerfiles/Dockerfile_1" \
-      org.opencontainers.image.documentation="https://github.com/vyta/openhack-containers/blob/master/src/tripviewer/README.md" \
+      org.opencontainers.image.url="https://github.com/Azure-Samples/openhack-containers/blob/master/dockerfiles/Dockerfile_1" \
+      org.opencontainers.image.documentation="https://github.com/Azure-Samples/openhack-containers/blob/master/src/tripviewer/README.md" \
       org.opencontainers.image.vendor="Microsoft" \
       org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.source="https://github.com/vyta/openhack-containers.git" \
+      org.opencontainers.image.source="https://github.com/Azure-Samples/openhack-containers.git" \
       org.opencontainers.image.revision=$IMAGE_SOURCE_REVISION 
 
 # add debugging utilities

--- a/dockerfiles/Dockerfile_2
+++ b/dockerfiles/Dockerfile_2
@@ -17,11 +17,11 @@ LABEL org.opencontainers.image.title="Trip Insights - User Profile API" \
       org.opencontainers.image.created=$IMAGE_CREATE_DATE \
       org.opencontainers.image.version=$IMAGE_VERSION \
       org.opencontainers.image.authors="Microsoft" \
-      org.opencontainers.image.url="https://github.com/vyta/openhack-containers/blob/master/dockerfiles/Dockerfile_2" \
-      org.opencontainers.image.documentation="https://github.com/vyta/openhack-containers/blob/master/src/userprofile/README.md" \
+      org.opencontainers.image.url="https://github.com/Azure-Samples/openhack-containers/blob/master/dockerfiles/Dockerfile_2" \
+      org.opencontainers.image.documentation="https://github.com/Azure-Samples/openhack-containers/blob/master/src/userprofile/README.md" \
       org.opencontainers.image.vendor="Microsoft" \
       org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.source="https://github.com/vyta/openhack-containers.git" \
+      org.opencontainers.image.source="https://github.com/Azure-Samples/openhack-containers.git" \
       org.opencontainers.image.revision=$IMAGE_SOURCE_REVISION 
 
 # add debugging utilities

--- a/dockerfiles/Dockerfile_3
+++ b/dockerfiles/Dockerfile_3
@@ -58,11 +58,11 @@ LABEL org.opencontainers.image.title="Trip Insights - POI (Points Of Interest) A
       org.opencontainers.image.created=$IMAGE_CREATE_DATE \
       org.opencontainers.image.version=$IMAGE_VERSION \
       org.opencontainers.image.authors="Microsoft" \
-      org.opencontainers.image.url="https://github.com/vyta/openhack-containers/blob/master/dockerfiles/Dockerfile_3" \
-      org.opencontainers.image.documentation="https://github.com/vyta/openhack-containers/blob/master/src/poi/README.md" \
+      org.opencontainers.image.url="https://github.com/Azure-Samples/openhack-containers/blob/master/dockerfiles/Dockerfile_3" \
+      org.opencontainers.image.documentation="https://github.com/Azure-Samples/openhack-containers/blob/master/src/poi/README.md" \
       org.opencontainers.image.vendor="Microsoft" \
       org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.source="https://github.com/vyta/openhack-containers.git" \
+      org.opencontainers.image.source="https://github.com/Azure-Samples/openhack-containers.git" \
       org.opencontainers.image.revision=$IMAGE_SOURCE_REVISION 
 
 # add debugging utilities

--- a/dockerfiles/Dockerfile_4
+++ b/dockerfiles/Dockerfile_4
@@ -30,11 +30,11 @@ LABEL org.opencontainers.image.title="Trip Insights - Trips API" \
       org.opencontainers.image.created=$IMAGE_CREATE_DATE \
       org.opencontainers.image.version=$IMAGE_VERSION \
       org.opencontainers.image.authors="Microsoft" \
-      org.opencontainers.image.url="https://github.com/vyta/openhack-containers/blob/master/dockerfiles/Dockerfile_4" \
-      org.opencontainers.image.documentation="https://github.com/vyta/openhack-containers/blob/master/src/trips/README.md" \
+      org.opencontainers.image.url="https://github.com/Azure-Samples/openhack-containers/blob/master/dockerfiles/Dockerfile_4" \
+      org.opencontainers.image.documentation="https://github.com/Azure-Samples/openhack-containers/blob/master/src/trips/README.md" \
       org.opencontainers.image.vendor="Microsoft" \
       org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.source="https://github.com/vyta/openhack-containers.git" \
+      org.opencontainers.image.source="https://github.com/Azure-Samples/openhack-containers.git" \
       org.opencontainers.image.revision=$IMAGE_SOURCE_REVISION 
 
 # add debugging utilities

--- a/src/poi/web/Startup.cs
+++ b/src/poi/web/Startup.cs
@@ -46,7 +46,7 @@ namespace poi
             // Register the Swagger generator, defining 1 or more Swagger documents
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("docs", new Info { Title = "Trip Insights Points Of Interest (POI) API", Description = "API for the trips in the Trip Insights app. https://github.com/vyta/openhack-containers", Version = "v1" });
+                c.SwaggerDoc("docs", new Info { Title = "Trip Insights Points Of Interest (POI) API", Description = "API for the trips in the Trip Insights app. https://github.com/Azure-Samples/openhack-containers", Version = "v1" });
             });
         }
 

--- a/src/trips/api/swagger.json
+++ b/src/trips/api/swagger.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "description": "API for the trips in the Trip Insights app. https://github.com/vyta/openhack-containers",
+    "description": "API for the trips in the Trip Insights app. https://github.com/Azure-Samples/openhack-containers",
     "version": "0.1.0",
     "title": "Trip Insights Trips API"
   },

--- a/src/user-java/src/main/java/io/swagger/configuration/SwaggerDocumentationConfig.java
+++ b/src/user-java/src/main/java/io/swagger/configuration/SwaggerDocumentationConfig.java
@@ -26,7 +26,7 @@ public class SwaggerDocumentationConfig extends WebMvcConfigurerAdapter {
     ApiInfo apiInfo() {
         return new ApiInfoBuilder()
             .title("Trip Insights User Profile (Java) API")
-            .description("API for the user profile in the Trip Insights app. https://github.com/vyta/openhack-containers")
+            .description("API for the user profile in the Trip Insights app. https://github.com/Azure-Samples/openhack-containers")
             .license("")
             .licenseUrl("http://unlicense.org")
             .termsOfServiceUrl("")

--- a/src/userprofile/config/swagger.json
+++ b/src/userprofile/config/swagger.json
@@ -1,7 +1,7 @@
 {
     "swagger": "2.0",
     "info": {
-        "description": "API for the user profile in the Trip Insights app. https://github.com/vyta/openhack-containers",
+        "description": "API for the user profile in the Trip Insights app. https://github.com/Azure-Samples/openhack-containers",
         "version": "0.1.0",
         "title": "Trip Insights User Profile API"
     },

--- a/src/userprofile/swagger/swagger.yaml
+++ b/src/userprofile/swagger/swagger.yaml
@@ -1,7 +1,7 @@
 ---
 swagger: "2.0"
 info:
-  description: "API for the user profile in the Trip Insights app. https://github.com/vyta/openhack-containers"
+  description: "API for the user profile in the Trip Insights app. https://github.com/Azure-Samples/openhack-containers"
   version: "0.1.0"
   title: "Trip Insights User Profile API"
 basePath: "/api"


### PR DESCRIPTION
Updating the container image metadata and swagger files to reference `https://github.com/Azure-Samples/openhack-containers` instead of `https://github.com/vyta/openhack-containers`.