### PR TITLE
Add configurable port for integration test to mitigate conflicts.

### DIFF
--- a/dockerfiles/Dockerfile_3
+++ b/dockerfiles/Dockerfile_3
@@ -24,6 +24,7 @@ RUN dotnet test
 
 FROM build-env AS integration-test
 WORKDIR /app/tests/IntegrationTests
+ENV WEB_INTEGRATION_PORT 8912
 RUN dotnet test
 
 FROM build-env AS publish

--- a/src/poi/README.md
+++ b/src/poi/README.md
@@ -73,6 +73,8 @@ Powershell
 docker build --no-cache --build-arg IMAGE_VERSION="1.0" --build-arg IMAGE_CREATE_DATE="$(Get-Date((Get-Date).ToUniversalTime()) -UFormat '%Y-%m-%dT%H:%M:%SZ')" --build-arg IMAGE_SOURCE_REVISION="$(git rev-parse HEAD)" -f Dockerfile -t "tripinsights/poi:1.0" .
 ```
 
+The docker build will run an integration stage (`FROM build-env AS integration-test`) where the application is run on the `WEB_INTEGRATION_PORT` port specified in the dockerfile. This should not conflict with anything on most machines. If you have a conflict with something running on your local machine, set the environment variable `WEB_INTEGRATION_PORT` to another unused port for the integration test.
+
 To run the image
 
 ```bash

--- a/src/poi/tests/IntegrationTests/CustomWebApplicationFactory.cs
+++ b/src/poi/tests/IntegrationTests/CustomWebApplicationFactory.cs
@@ -20,6 +20,10 @@ namespace IntegrationTests
             .AddEnvironmentVariables()
             .Build();
 
+            var port = Environment.GetEnvironmentVariable("WEB_INTEGRATION_PORT") ?? "8123";
+            Environment.SetEnvironmentVariable("WEB_INTEGRATION_PORT", port);
+            Console.WriteLine("Spinning up site for testing on port " + port);
+
             var host = new WebHostBuilder()
                 .UseKestrel()
                 .UseConfiguration(configuration)
@@ -31,7 +35,7 @@ namespace IntegrationTests
                     logging.AddDebug();
                 })
                 .UseStartup<IntegrationTests.Startup>()
-                .UseUrls("http://localhost:8080");
+                .UseUrls("http://localhost:" + port);
 
             return host;
         }

--- a/src/poi/tests/IntegrationTests/POITests.cs
+++ b/src/poi/tests/IntegrationTests/POITests.cs
@@ -26,10 +26,12 @@ namespace IntegrationTests
         [InlineData("/api/poi/")]
         public async Task Get_EndpointsReturnSuccessAndCorrectContentType(string url)
         {
+            var port = Environment.GetEnvironmentVariable("WEB_INTEGRATION_PORT");
+
             // Arrange
             var client = _factory.CreateClient(
                 new WebApplicationFactoryClientOptions{
-                    BaseAddress = new Uri("http://localhost:8080")
+                    BaseAddress = new Uri("http://localhost:" + port)
                 }
             );
 


### PR DESCRIPTION
Sometimes folks have port `8080` in use on their machine and the integration test that runs as part of the `docker build` will fail. This sets a non-standard port for the integration test and allows for that value to be overridden with the `WEB_INTEGRATION_PORT` environment variable.